### PR TITLE
Add phase 1 rehearsal baseline and runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+outputs/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Continual learning systems struggle with **catastrophic forgetting**—models lo
 
 > **Core Hypothesis**: By combining iCaRL with ADWIN we can build an *adaptive* rehearsal strategy that reacts only when forgetting is detected, preserving accuracy while reducing rehearsal cost.
 
+> 📄 **Mid-Semester Dossier**: A comprehensive narrative covering background, methodology, experimental roadmap, and presentation outline is available in [`docs/mid-semester-review.md`](docs/mid-semester-review.md).
+>
+> 🧪 **Phase 1 Baseline Code**: Run the SplitMNIST rehearsal baseline and generate report-ready plots using [`experiments/phase1/rehearsal_baseline.py`](experiments/phase1/rehearsal_baseline.py). Step-by-step instructions live in [`docs/mid-semester-runbook.md`](docs/mid-semester-runbook.md).
+
 ---
 
 ## 2. Current Idea Review

--- a/docs/end-semester-coding-plan.md
+++ b/docs/end-semester-coding-plan.md
@@ -1,0 +1,95 @@
+---
+title: "End-Semester Implementation Plan"
+author: "Abhinav"
+date: "September 2025"
+---
+
+# Smart Rehearsal Coding Plan for End-Semester Evaluation
+
+## 1. Goal Alignment
+- **Objective**: Deliver a production-ready prototype that fuses static rehearsal strength (iCaRL) with adaptive monitoring (ADWIN) to surpass baseline accuracy-for-cost trade-offs.
+- **Key Question**: How does the combined strategy outperform pure rehearsal or pure drift detection in retaining past knowledge while scaling to new tasks?
+- **Success Criteria**: Demonstrate superior average accuracy, reduced forgetting, and lower cumulative replay budget versus fixed-schedule baselines across class-incremental benchmarks.
+
+## 2. Current Assets Recap
+| Asset | Status | Notes |
+|-------|--------|-------|
+| Literature review + baseline scripts | ✅ Completed | ER, GEM reference implementations ready for comparison |
+| iCaRL backbone draft | 🔄 Partial | Needs refactor into modular trainer/service layers |
+| ADWIN monitor prototype | 🔄 Partial | Works on synthetic drift; pending integration hooks |
+| Logging notebooks | ✅ Available | To be promoted into reusable utilities |
+
+## 3. Target Architecture Overview
+```
+Streaming Dataset  -->  Data Loader  -->  Incremental Trainer  -->  Metrics Buffer  -->  ADWIN Monitor
+                                                   |                                    |
+                                                   v                                    |
+                                      Exemplar Memory Manager <-------------------------
+                                                   |
+                                                   v
+                                           Adaptive Rehearsal Scheduler
+```
+- **Incremental Trainer**: Maintains feature extractor + nearest-mean classifier heads.
+- **Metrics Buffer**: Collects rolling validation accuracy/loss for drift analysis.
+- **Adaptive Scheduler**: Chooses between light-touch rehearsal (mini replay) and heavy refresh (balanced fine-tuning + exemplar update).
+
+## 4. Module Breakdown & Coding Tasks
+### 4.1 Data & Experiment Orchestration
+- Implement a unified CLI (`train.py`) that configures dataset splits, buffer sizes, and ADWIN parameters.
+- Add reproducible experiment manifests (YAML) to describe runs for CIFAR-10/100 and Tiny-ImageNet.
+
+### 4.2 Backbone Trainer Enhancements
+- Refactor iCaRL code into: `FeatureExtractor`, `ExemplarManager`, and `IncrementalLearner` classes.
+- Introduce hooks for lightweight rehearsal steps (mini-batch replay) and full balanced fine-tuning.
+- Ensure exemplar selection uses herding with class-balanced quotas.
+
+### 4.3 Monitoring & Adaptive Control
+- Wrap River's ADWIN in a `DriftDetector` interface with reset, confidence, and window diagnostics.
+- Design a `MetricStream` publisher that feeds accuracy/loss events to detectors asynchronously.
+- Implement policy logic: `if detector.triggered(): schedule_full_rehearsal()` else continue light replay.
+
+### 4.4 Evaluation & Comparative Analysis
+- Create evaluation scripts to compute per-task accuracy, forgetting, and cumulative replay counts.
+- Add plotting utilities for accuracy vs. time and compute vs. accuracy trade-offs.
+- Automate baselines (static rehearsal, ER) with identical experiment manifests for fair comparison.
+
+### 4.5 Engineering Quality
+- Integrate Hydra or argparse-based configuration logging for reproducibility.
+- Add unit tests for exemplar selection, detector triggering, and rehearsal scheduling decisions.
+- Configure CI hooks (pytest + lint) to run on push.
+
+## 5. Development Iterations
+| Iteration | Focus | Deliverables |
+|-----------|-------|--------------|
+| I1 (Week 8-9) | Modularize trainer & memory | Refactored classes, baseline parity tests |
+| I2 (Week 9-10) | Integrate ADWIN control loop | Drift detector interface, event logging |
+| I3 (Week 10-11) | Adaptive rehearsal policies | Policy unit tests, initial ablation results |
+| I4 (Week 11-12) | Benchmark automation | Manifest-driven runs, reproducibility scripts |
+| I5 (Week 12-13) | Analysis & visualization | Comparison plots, trade-off tables |
+| I6 (Week 13-14) | Polish & documentation | API docs, deployment checklist |
+
+## 6. Comparative Advantage Narrative
+- **Static Rehearsal vs. Smart Rehearsal**: Expect lower replay volume (compute) while matching or exceeding accuracy due to targeted interventions.
+- **Pure Drift Detection vs. Smart Rehearsal**: ADWIN alone detects change but cannot recover performance; coupling with rehearsal yields measurable retention gains.
+- **Combined Storyline**: Present joint metrics (accuracy, forgetting, replay steps) demonstrating Smart Rehearsal dominates both baselines on efficiency-frontier plots.
+
+## 7. Risk Mitigation & Contingencies
+| Risk | Mitigation |
+|------|------------|
+| ADWIN false positives causing excess rehearsal | Parameter sweep, incorporate patience counter before triggering full refresh |
+| Memory growth with many classes | Implement adaptive pruning + reservoir sampling fallback |
+| Training instability on Tiny-ImageNet | Use mixed-precision and gradient clipping; provide smaller backbone alternative |
+| Time constraints for full ablations | Prioritize CIFAR-100 results; treat Tiny-ImageNet as stretch goal |
+
+## 8. Documentation & Presentation Artifacts
+- Maintain a changelog highlighting integration milestones and experimental outcomes.
+- Prepare slide-ready figures: system architecture, comparison plots, replay budget chart.
+- Draft narrative linking literature gap → implementation → empirical evidence for the end-semester defense.
+
+## 9. Reference Backbone
+1. Rebuffi, S.-A., et al. "iCaRL: Incremental Classifier and Representation Learning." CVPR 2017.
+2. van de Ven, G. M., and Tolias, A. S. "Three Scenarios for Continual Learning." arXiv:1904.07734, 2019.
+3. Bifet, A., and Gavaldà, R. "Learning from Time-Changing Data with Adaptive Windowing." SDM 2007.
+4. Hayes, T. L., et al. "REMIND Your Neural Network to Prevent Catastrophic Forgetting." ECCV 2020.
+5. Montiel, J., et al. "River: Machine Learning for Streaming Data in Python." JMLR 2021.
+

--- a/docs/mid-semester-review.md
+++ b/docs/mid-semester-review.md
@@ -1,0 +1,171 @@
+---
+title: "Mid-Semester Review Report"
+author: "Abhinav"
+date: "September 2025"
+---
+
+# Adaptive Rehearsal for Continual Learning
+## Mid-Semester Evaluation Dossier
+
+## Abstract
+Catastrophic forgetting remains a central challenge in continual learning: models trained on streaming tasks tend to lose performance on previously learned tasks. Classic rehearsal-based approaches such as iCaRL mitigate forgetting by replaying buffered exemplars, but they incur constant computational overhead, even when the model is stable. This project proposes **Smart Rehearsal**, an adaptive pipeline that couples exemplar-based rehearsal with the Adaptive Windowing (ADWIN) concept-drift detector. By triggering intensive rehearsal only when performance degradation is detected, the system aims to retain accuracy while reducing unnecessary computation. This mid-semester report documents the problem context, literature foundations, system design, progress to date, planned experiments, and the roadmap to the final submission.
+
+---
+
+## Executive Status Overview
+- **Mid-Semester Goal**: Deliver a validated problem statement, baseline reproducibility, and an integration-ready design for the Smart Rehearsal pipeline.
+- **Completed Artefacts**: Literature matrix, baseline ER/GEM scripts, iCaRL backbone draft, ADWIN monitoring prototype notes, project risk log, presentation outline.
+- **In-Progress Focus**: Finalising iCaRL exemplar policy benchmarking and calibrating ADWIN thresholds on synthetic drift streams prior to full pipeline integration.
+- **Upcoming (Pre Mid-Sem Review)**: Assemble annotated architecture diagram, consolidate calibration results into slides, and rehearse the presentation narrative using Appendix A.
+- **Outstanding (Post Mid-Sem Review)**: Implement adaptive trigger loop, run comparative studies, and prepare final reproducibility package ahead of the end-semester evaluation.
+
+---
+
+## 1. Introduction
+- **Problem Context**: Sequential data streams require models that adapt without revisiting the entire dataset. Traditional deep learning models retrained from scratch are inefficient for such scenarios.
+- **Research Gap**: Rehearsal-based continual learning methods achieve competitive accuracy but treat replay frequency as fixed. This static strategy wastes resources during stable phases and may still miss fast-onset forgetting.
+- **Project Hypothesis**: Monitoring validation performance with ADWIN can signal genuine forgetting events, allowing the system to trigger rehearsal bursts only when necessary, thus balancing retention and efficiency.
+
+---
+
+## 2. Background and Related Work
+1. **Rehearsal-Based Methods**
+   - *Experience Replay (ER)* maintains a memory buffer of past samples for joint training.
+   - *iCaRL* introduces exemplar selection and prototype-based classification for incremental class learning.
+2. **Regularization-Based Methods**
+   - Techniques such as EWC penalize changes to important weights but rely on stationary task boundaries.
+3. **Dynamic Architectures**
+   - Progressive Networks and Dynamic Expansion methods grow model capacity, trading off memory and inference cost.
+4. **Concept Drift Detection**
+   - ADWIN offers adaptive windowing to detect statistically significant changes in streaming metrics.
+5. **Open Source Tooling**
+   - The River library and Avalanche provide streaming ML utilities and continual learning baselines, informing our implementation strategy.
+
+---
+
+## 3. Proposed Solution: Smart Rehearsal Pipeline
+### 3.1 System Modules
+- **Data Stream Ingestion**: Handles sequential tasks (Split CIFAR-10/100, Tiny-ImageNet) with configurable task orders.
+- **Backbone Learner**: iCaRL-inspired encoder and classifier supporting exemplar buffers.
+- **Monitoring Layer**: Records accuracy on exemplar-based validation streams.
+- **ADWIN Trigger**: Evaluates metric streams to flag performance drops.
+- **Adaptive Rehearsal Manager**: On drift detection, initiates intensive rehearsal (balanced fine-tuning, exemplar refresh).
+- **Logging & Visualization**: Aggregates metrics (accuracy, forgetting, compute cost) into dashboards for analysis.
+
+### 3.2 Data Flow
+1. Receive new task batches.
+2. Update the model using incremental training.
+3. Evaluate held-out exemplar batches and feed results into ADWIN.
+4. If drift detected → trigger rehearsal cycle; else continue streaming updates.
+5. Periodically log metrics and update dashboards.
+
+---
+
+## 4. Methodology and Work Completed
+| Phase | Timeline (Weeks) | Status | Key Artifacts |
+|-------|------------------|--------|---------------|
+| Literature Review & Baseline Plan | 1–2 | ✅ Completed | Survey notes, baseline experiment design |
+| Baseline Reproduction (ER, GEM) | 2–3 | ✅ Completed | Baseline scripts, evaluation harness |
+| iCaRL Implementation | 3–5 | 🔄 In Progress | Backbone architecture draft, exemplar policy module |
+| ADWIN Integration & Calibration | 5–7 | 🔄 In Progress | Concept-drift monitor prototype, calibration notebook |
+| Adaptive Rehearsal Prototype | 7–9 | ⏳ Scheduled | Integration plan, interface design |
+| Extended Evaluation Setup | 9–11 | ⏳ Scheduled | Tiny-ImageNet stream, compute logging |
+| Report & Presentation Prep | 12–15 | ⏳ Scheduled | Final report outline, deck skeleton |
+
+---
+
+## 5. Experimental Plan (for End-Semester Evaluation)
+1. **Datasets**
+   - Split CIFAR-10, Split CIFAR-100, Tiny-ImageNet (class-incremental protocols).
+2. **Baselines**
+   - Static Rehearsal (iCaRL with fixed replay schedule).
+   - Experience Replay (fixed buffer, SGD).
+   - Regularization Baselines (EWC, SI) as references if time allows.
+3. **Metrics**
+   - Accuracy per task and overall.
+   - Forgetting measure (max accuracy drop per task).
+   - Computational cost: number of replay steps, GPU time.
+4. **Ablation Studies**
+   - Vary ADWIN parameters (confidence, min window length).
+   - Compare adaptive vs. fixed rehearsal frequency.
+5. **Visualization**
+   - Performance vs. time plots highlighting drift detections.
+   - Compute vs. accuracy trade-off charts.
+
+---
+
+## 6. Risk Assessment & Mitigation
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| ADWIN sensitivity too high/low | False alarms or missed forgetting events | Parameter sweep, fallback to fixed schedule |
+| Exemplar buffer overflow | Increased memory footprint | Adaptive pruning strategies, class-balanced selection |
+| Limited compute resources | Longer training cycles | Early stopping strategies, smaller backbone for experiments |
+| Integration complexity | Delayed prototype | Modular interfaces, incremental testing |
+
+---
+
+## 7. Deliverables for Mid-Semester Review
+- Problem statement and motivation slides.
+- Literature matrix comparing continual learning strategies.
+- System architecture diagram of Smart Rehearsal pipeline.
+- Baseline reproduction notebooks and logs.
+- ADWIN calibration results on synthetic streams.
+- Project timeline and risk register.
+
+---
+
+## 8. Roadmap to End-Semester Report
+- Complete adaptive rehearsal integration and run full experiment suite.
+- Generate comparative analysis (accuracy, forgetting, compute usage).
+- Prepare reproducibility checklist and code documentation.
+- Draft final report synthesizing quantitative and qualitative findings.
+- Build final presentation deck and demo (if feasible).
+
+---
+
+## 9. References
+1. Rebuffi, S.-A., et al. *"iCaRL: Incremental Classifier and Representation Learning."* CVPR, 2017.
+2. van de Ven, G. M., and Tolias, A. S. *"Three Scenarios for Continual Learning."* arXiv:1904.07734, 2019.
+3. Bifet, A., and Gavalda, R. *"Learning from Time-Changing Data with Adaptive Windowing."* SDM, 2007.
+4. Montiel, J., et al. *"River: Machine Learning for Streaming Data in Python."* JMLR, 2021.
+5. Lopez-Paz, D., and Ranzato, M. *"Gradient Episodic Memory for Continual Learning."* NIPS, 2017.
+6. Kirkpatrick, J., et al. *"Overcoming Catastrophic Forgetting in Neural Networks."* PNAS, 2017.
+
+---
+
+## Appendix A. Presentation Script Outline
+1. **Opening (1 min)**
+   - Introduce continual learning challenge and stakes for real-world deployment.
+   - State the Smart Rehearsal hypothesis.
+2. **Motivation (2 min)**
+   - Illustrate catastrophic forgetting and inefficiency of static rehearsal with visuals.
+   - Position ADWIN as a proven tool for drift detection.
+3. **Technical Approach (4 min)**
+   - Walk through modular pipeline, emphasise monitoring-trigger loop.
+   - Highlight how exemplar buffers and ADWIN interact.
+4. **Progress to Date (2 min)**
+   - Summarise completed baselines, prototype modules, and calibration experiments.
+5. **Next Steps (2 min)**
+   - Outline upcoming integration, evaluation, and documentation milestones.
+6. **Closing (1 min)**
+   - Reiterate contributions, expected benefits, and invite feedback.
+
+## Appendix B. Resource Checklist
+- **Compute**: Access to at least one GPU-equipped workstation (12GB+) for rehearsal experiments.
+- **Software Stack**: PyTorch, Avalanche, River, Weights & Biases for experiment tracking.
+- **Data Management**: Scripted downloaders for CIFAR variants and Tiny-ImageNet, with checksum verification.
+- **Collaboration**: Shared Notion space for notes, GitHub Project board for task tracking.
+
+---
+
+## Appendix C. Risk Register Snapshot
+| ID | Description | Probability | Impact | Owner | Mitigation |
+|----|-------------|-------------|--------|-------|------------|
+| R1 | ADWIN miscalibration causes oscillating triggers | Medium | High | Abhinav | Parameter tuning, smoothing metrics |
+| R2 | Dataset download delays | Low | Medium | Abhinav | Pre-download, maintain mirror |
+| R3 | GPU availability conflicts | Medium | Medium | Abhinav | Schedule runs off-peak, enable resume |
+| R4 | Report scope creep | Medium | Low | Abhinav | Weekly check-ins, freeze feature list |
+
+---
+
+*Prepared for the Mid-Semester Review to showcase project vision, progress, and execution plan.*

--- a/docs/mid-semester-runbook.md
+++ b/docs/mid-semester-runbook.md
@@ -1,0 +1,77 @@
+# Mid-Semester Experiment Runbook
+
+This guide explains how to execute the Phase 1 rehearsal baseline, collect metrics for the mid-semester review, and incorporate comparative visuals into the LaTeX report.
+
+## 1. Environment Setup
+
+1. **Create a virtual environment (recommended):**
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
+   ```
+2. **Install dependencies:**
+   ```bash
+   pip install torch torchvision matplotlib
+   ```
+   *For GPU acceleration, install the CUDA-enabled wheel from the [official PyTorch instructions](https://pytorch.org/get-started/locally/).*  
+   Additional tools such as `jupyter` or `tensorboard` can be installed on demand.
+
+## 2. Run the Phase 1 Baseline
+
+The first milestone is to reproduce a rehearsal baseline on SplitMNIST. This serves as the comparison point for the adaptive Smart Rehearsal pipeline.
+
+```bash
+python -m experiments.phase1.rehearsal_baseline \
+    --epochs 5 \
+    --buffer-size 200 \
+    --plot
+```
+
+### Command Arguments
+- `--epochs`: Training epochs per task (default: 5).
+- `--buffer-size`: Total capacity of the exemplar buffer (default: 200).
+- `--batch-size`: Mini-batch size for SGD (default: 64).
+- `--lr`: Learning rate (default: 1e-3).
+- `--output-dir`: Where metrics and plots are stored (default: `outputs/phase1`).
+- `--plot`: Save `phase1_accuracy.png` for presentation/report use.
+
+After the run completes, the following artefacts are produced:
+
+| File | Description |
+| --- | --- |
+| `outputs/phase1/phase1_metrics.json` | Per-task accuracy, seen classes, buffer usage. |
+| `outputs/phase1/phase1_metrics.csv` | CSV view of the same metrics for spreadsheets. |
+| `outputs/phase1/phase1_accuracy.png` | Accuracy curve (only when `--plot` is enabled). |
+
+## 3. Comparative Analysis Checklist
+
+To prepare mid-semester slides or documentation:
+
+1. **Baseline Table:** Import `phase1_metrics.csv` into Google Sheets/Excel to summarise accuracy after each incremental task.
+2. **Buffer Utilisation:** Highlight the `rehearsal_examples` column to show memory footprint.
+3. **Narrative Hooks:** Connect accuracy plateau/drops to hypotheses about static rehearsal.
+
+These artefacts become the "before" scenario for the end-semester adaptive experiments.
+
+## 4. Embedding Results in LaTeX
+
+1. Copy `outputs/phase1/phase1_accuracy.png` into your report's `figures/` directory.
+2. Reference it in LaTeX:
+   ```latex
+   \begin{figure}[h]
+     \centering
+     \includegraphics[width=0.7\textwidth]{figures/phase1_accuracy.png}
+     \caption{Phase 1 rehearsal baseline accuracy across SplitMNIST tasks.}
+     \label{fig:phase1-baseline}
+   \end{figure}
+   ```
+3. For tabular metrics, convert the CSV into a LaTeX table using an online converter or the `pandas.DataFrame.to_latex()` method.
+4. Cite relevant literature inline (e.g., \cite{rebuffi2017icarl}) to contextualise the baseline.
+
+## 5. Next Steps (Preview)
+
+- **Phase 2:** Integrate ADWIN monitoring to detect drift triggers.
+- **Phase 3:** Implement adaptive rehearsal policy and rerun experiments.
+- **Phase 4:** Prepare comparative plots (static vs. adaptive) and discuss compute savings.
+
+Document results from each phase in the same `outputs/` hierarchy to maintain a reproducible audit trail.

--- a/experiments/phase1/rehearsal_baseline.py
+++ b/experiments/phase1/rehearsal_baseline.py
@@ -1,0 +1,301 @@
+"""Phase 1 baseline experiments for the Smart Rehearsal project.
+
+This module trains a simple multi-layer perceptron on SplitMNIST with
+experience replay. The goal is to provide a reproducible baseline for the
+mid-semester review where we can showcase rehearsal vs. non-rehearsal
+performance and export accuracy curves for the report.
+
+Example usage:
+    python -m experiments.phase1.rehearsal_baseline --epochs 5 --buffer-size 200
+
+Outputs are saved to the ``outputs/phase1`` directory by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+import torch
+from torch import nn, optim
+from torch.utils.data import DataLoader, Dataset, Subset
+from torchvision import datasets, transforms
+
+TASKS: Tuple[Tuple[int, int], ...] = (
+    (0, 1),
+    (2, 3),
+    (4, 5),
+    (6, 7),
+    (8, 9),
+)
+
+
+def set_seed(seed: int = 42) -> None:
+    random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+class MLP(nn.Module):
+    """Light-weight classifier for SplitMNIST."""
+
+    def __init__(self, hidden_size: int = 256, num_classes: int = 10) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(28 * 28, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, hidden_size),
+            nn.ReLU(),
+            nn.Linear(hidden_size, num_classes),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class RehearsalBuffer:
+    """Fixed-capacity exemplar buffer storing (image, label) pairs."""
+
+    def __init__(self, capacity: int) -> None:
+        self.capacity = capacity
+        self.storage: Dict[int, List[torch.Tensor]] = {}
+
+    def __len__(self) -> int:
+        return sum(len(samples) for samples in self.storage.values())
+
+    def add_samples(self, images: torch.Tensor, labels: torch.Tensor) -> None:
+        if self.capacity <= 0:
+            return
+        for img, label in zip(images, labels):
+            label_int = int(label.item())
+            self.storage.setdefault(label_int, []).append(img.cpu())
+        self._reduce()
+
+    def sample(self, batch_size: int) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.capacity <= 0 or len(self) == 0:
+            raise ValueError("Buffer is empty")
+        images = []
+        labels = []
+        available = [(cls, sample) for cls, samples in self.storage.items() for sample in samples]
+        chosen = random.sample(available, k=min(batch_size, len(available)))
+        for cls, sample in chosen:
+            images.append(sample.unsqueeze(0))
+            labels.append(torch.tensor([cls], dtype=torch.long))
+        return torch.cat(images, dim=0), torch.cat(labels, dim=0)
+
+    def iter_all(self) -> Iterable[Tuple[torch.Tensor, torch.Tensor]]:
+        for cls, samples in self.storage.items():
+            for sample in samples:
+                yield sample, torch.tensor(cls, dtype=torch.long)
+
+    def _reduce(self) -> None:
+        total = len(self)
+        if total <= self.capacity:
+            return
+        # simple class-balanced pruning
+        per_class = max(1, self.capacity // max(len(self.storage), 1))
+        for cls, samples in list(self.storage.items()):
+            random.shuffle(samples)
+            self.storage[cls] = samples[:per_class]
+
+
+@dataclass
+class TrainingConfig:
+    epochs: int = 5
+    batch_size: int = 64
+    buffer_size: int = 200
+    lr: float = 1e-3
+    device: str = "cuda" if torch.cuda.is_available() else "cpu"
+    output_dir: Path = Path("outputs/phase1")
+    download: bool = True
+
+
+@dataclass
+class TaskMetrics:
+    task_id: int
+    seen_classes: List[int]
+    accuracy: float
+    rehearsal_examples: int
+
+
+def load_split_mnist(root: str, train: bool, download: bool) -> datasets.MNIST:
+    transform = transforms.Compose([transforms.ToTensor()])
+    return datasets.MNIST(root=root, train=train, download=download, transform=transform)
+
+
+def filter_dataset(dataset: Dataset, classes: Tuple[int, int]) -> Subset:
+    indices = [i for i, (_, label) in enumerate(dataset) if label in classes]
+    return Subset(dataset, indices)
+
+
+def evaluate(model: nn.Module, loader: DataLoader, device: str) -> float:
+    model.eval()
+    correct = 0
+    total = 0
+    with torch.no_grad():
+        for images, labels in loader:
+            images = images.to(device)
+            labels = labels.to(device)
+            logits = model(images)
+            preds = logits.argmax(dim=1)
+            correct += (preds == labels).sum().item()
+            total += labels.size(0)
+    return correct / total if total > 0 else 0.0
+
+
+def rehearsal_training(config: TrainingConfig) -> List[TaskMetrics]:
+    set_seed()
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    device = config.device
+    model = MLP().to(device)
+    optimizer = optim.Adam(model.parameters(), lr=config.lr)
+    criterion = nn.CrossEntropyLoss()
+
+    buffer = RehearsalBuffer(config.buffer_size)
+    train_dataset = load_split_mnist("./data", train=True, download=config.download)
+    test_dataset = load_split_mnist("./data", train=False, download=config.download)
+
+    metrics: List[TaskMetrics] = []
+
+    for task_id, classes in enumerate(TASKS, start=1):
+        subset = filter_dataset(train_dataset, classes)
+        loader = DataLoader(subset, batch_size=config.batch_size, shuffle=True)
+
+        for epoch in range(config.epochs):
+            model.train()
+            for images, labels in loader:
+                images = images.to(device)
+                labels = labels.to(device)
+
+                if len(buffer) > 0:
+                    try:
+                        buf_images, buf_labels = buffer.sample(config.batch_size)
+                    except ValueError:
+                        buf_images = buf_labels = None
+                    else:
+                        buf_images = buf_images.to(device)
+                        buf_labels = buf_labels.to(device)
+                        images = torch.cat([images, buf_images], dim=0)
+                        labels = torch.cat([labels, buf_labels], dim=0)
+
+                logits = model(images)
+                loss = criterion(logits, labels)
+
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+            # add samples from current task to buffer at end of each epoch
+            all_images = []
+            all_labels = []
+            for batch_images, batch_labels in loader:
+                all_images.append(batch_images)
+                all_labels.append(batch_labels)
+            buffer.add_samples(torch.cat(all_images, dim=0), torch.cat(all_labels, dim=0))
+
+        seen_classes = [c for task_classes in TASKS[:task_id] for c in task_classes]
+        eval_subset = filter_dataset(test_dataset, tuple(seen_classes))
+        eval_loader = DataLoader(eval_subset, batch_size=256)
+        acc = evaluate(model, eval_loader, device)
+        metrics.append(
+            TaskMetrics(
+                task_id=task_id,
+                seen_classes=seen_classes,
+                accuracy=acc,
+                rehearsal_examples=len(buffer),
+            )
+        )
+
+    return metrics
+
+
+def save_metrics(metrics: List[TaskMetrics], output_dir: Path) -> None:
+    payload = [asdict(m) for m in metrics]
+    metrics_file = output_dir / "phase1_metrics.json"
+    with metrics_file.open("w", encoding="utf-8") as fp:
+        json.dump(payload, fp, indent=2)
+
+    # also create a CSV for quick inspection
+    csv_file = output_dir / "phase1_metrics.csv"
+    with csv_file.open("w", encoding="utf-8") as fp:
+        fp.write("task_id,seen_classes,accuracy,rehearsal_examples\n")
+        for m in metrics:
+            classes_str = "|".join(str(c) for c in m.seen_classes)
+            fp.write(f"{m.task_id},{classes_str},{m.accuracy:.4f},{m.rehearsal_examples}\n")
+
+
+def plot_metrics(metrics: List[TaskMetrics], output_dir: Path) -> Path:
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise RuntimeError(
+            "matplotlib is required for plotting. Install it with 'pip install matplotlib'."
+        ) from exc
+    tasks = [m.task_id for m in metrics]
+    accuracies = [m.accuracy for m in metrics]
+
+    plt.figure(figsize=(6, 4))
+    plt.plot(tasks, accuracies, marker="o", label="Accuracy")
+    plt.ylim(0, 1.0)
+    plt.xticks(tasks)
+    plt.xlabel("Task")
+    plt.ylabel("Accuracy")
+    plt.title("Phase 1 Rehearsal Baseline (SplitMNIST)")
+    plt.grid(True, linestyle="--", alpha=0.4)
+    plt.legend()
+    output_path = output_dir / "phase1_accuracy.png"
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=300)
+    plt.close()
+    return output_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Phase 1 rehearsal baseline experiment")
+    parser.add_argument("--epochs", type=int, default=5, help="Training epochs per task")
+    parser.add_argument("--batch-size", type=int, default=64, help="Mini-batch size")
+    parser.add_argument("--buffer-size", type=int, default=200, help="Total rehearsal buffer capacity")
+    parser.add_argument("--lr", type=float, default=1e-3, help="Learning rate")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("outputs/phase1"),
+        help="Directory to store metrics and plots",
+    )
+    parser.add_argument("--no-download", action="store_true", help="Do not download datasets")
+    parser.add_argument(
+        "--plot",
+        action="store_true",
+        help="Generate accuracy plot for inclusion in the report",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = TrainingConfig(
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        buffer_size=args.buffer_size,
+        lr=args.lr,
+        output_dir=args.output_dir,
+        download=not args.no_download,
+    )
+
+    metrics = rehearsal_training(config)
+    save_metrics(metrics, config.output_dir)
+
+    if args.plot:
+        plot_path = plot_metrics(metrics, config.output_dir)
+        print(f"Saved accuracy plot to: {plot_path}")
+
+    print(f"Stored metrics for {len(metrics)} tasks in {config.output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a SplitMNIST rehearsal baseline script to showcase the mid-semester comparison point and export metrics/plots
- document setup, execution steps, and LaTeX embedding guidance in a mid-semester runbook and link it from the README
- ignore build artefacts/outputs so experiment runs remain clean in version control

## Testing
- python -m compileall experiments/phase1

------
https://chatgpt.com/codex/tasks/task_e_68d7faaf564883319da11bf593c853ed